### PR TITLE
188_workaround for test cases to run without session exception

### DIFF
--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/ButtonTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/ButtonTest.java
@@ -1,41 +1,39 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-
+import com.capgemini.mrchecker.selenium.core.BasePage;
+import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
+import com.capgemini.mrchecker.test.core.BaseTest;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.capgemini.mrchecker.selenium.core.BasePage;
-import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
-import com.capgemini.mrchecker.test.core.BaseTest;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 /**
  * Created by LKURZAJ on 03.03.2017.
  */
 public class ButtonTest extends BaseTest {
-	
-	private static By buttonSubmit = By.cssSelector("button#submit");
-	
+	private        QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+	private static By                   buttonSubmit         = By.cssSelector("button#submit");
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
+
 	}
-	
+
 	@Test
 	public void test() {
 		// check if element is displayed
 		assertTrue(BasePage.getDriver()
 				.elementButton(ButtonTest.buttonSubmit)
 				.isDisplayed());
-		
+
 		// check if element type equals Button
 		assertEquals("Button", BasePage.getDriver()
 				.elementButton(ButtonTest.buttonSubmit)
 				.getElementTypeName());
-		
+
 		// click on button and verify if url was changed
 		BasePage.getDriver()
 				.elementButton(ButtonTest.buttonSubmit)
@@ -44,14 +42,15 @@ public class ButtonTest extends BaseTest {
 				.getCurrentUrl()
 				.contains("&submit="));
 	}
-	
+
 	@Override
 	public void setUp() {
+		quickFixSeleniumPage = new QuickFixSeleniumPage();
 		BasePage.getDriver()
 				.get(PageSubURLsEnum.TOOLS_QA.subURL() + PageSubURLsEnum.AUTOMATION_PRACTICE_FORM.subURL());
 		return;
 	}
-	
+
 	@Override
 	public void tearDown() {
 		// TODO Auto-generated method stub

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/CheckBoxTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/CheckBoxTest.java
@@ -1,33 +1,29 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.CheckBox;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static org.junit.Assert.*;
 
 /**
  * Created by LKURZAJ on 06.03.2017.
  */
 public class CheckBoxTest extends BaseTest {
-	
-	private static final By hobbyCheckBoxSelector = By
+	private              QuickFixSeleniumPage quickFixSeleniumPage  = new QuickFixSeleniumPage();
+	private static final By                   hobbyCheckBoxSelector = By
 			.cssSelector("li.fields.pageFields_1:nth-child(3) div.radio_wrap");
 	CheckBox checkBoxElement;
-	
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
+
 	}
-	
+
 	@Test
 	public void testCheckBoxByIndex() {
 		checkBoxElement.setCheckBoxByIndex(0);
@@ -35,7 +31,7 @@ public class CheckBoxTest extends BaseTest {
 		checkBoxElement.unsetCheckBoxByIndex(0);
 		assertFalse(checkBoxElement.isCheckBoxSetByIndex(0));
 	}
-	
+
 	@Test
 	public void testCheckBoxByValue() {
 		checkBoxElement.setCheckBoxByValue("reading");
@@ -43,22 +39,22 @@ public class CheckBoxTest extends BaseTest {
 		checkBoxElement.unsetCheckBoxByValue("reading");
 		assertFalse(checkBoxElement.isCheckBoxSetByValue("reading"));
 	}
-	
+
 	@Test
 	public void testCheckBoxByText() {
 		checkBoxElement.setCheckBoxByText("Cricket");
 		assertTrue(checkBoxElement.isCheckBoxSetByText("Cricket"));
 		checkBoxElement.unsetCheckBoxByText("Cricket");
 		assertFalse(checkBoxElement.isCheckBoxSetByText("Cricket"));
-		
+
 	}
-	
+
 	@Test
 	public void testNumberOfCheckBoxes() {
 		assertEquals(checkBoxElement.getTextList()
 				.size(), 3);
 	}
-	
+
 	@Test
 	public void testCheckBoxAllValues() {
 		checkBoxElement.setAllCheckBoxes();
@@ -66,7 +62,7 @@ public class CheckBoxTest extends BaseTest {
 		checkBoxElement.unsetAllCheckBoxes();
 		assertFalse(checkBoxElement.isAllCheckboxesSet());
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
@@ -74,7 +70,7 @@ public class CheckBoxTest extends BaseTest {
 		this.checkBoxElement = BasePage.getDriver()
 				.elementCheckbox(CheckBoxTest.hobbyCheckBoxSelector);
 	}
-	
+
 	@Override
 	public void tearDown() {
 	}

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/DropdownListTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/DropdownListTest.java
@@ -1,62 +1,60 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.DropdownListElement;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by LKURZAJ on 06.03.2017.
  */
 public class DropdownListTest extends BaseTest {
-	
-	private static final By dropdownSelector = By.cssSelector("select#dropdown_7");
-	private DropdownListElement dropdownObject;
-	
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+
+	private static final By                  dropdownSelector = By.cssSelector("select#dropdown_7");
+	private              DropdownListElement dropdownObject;
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
 	}
-	
+
 	@Test
 	public void testPossibleOptionsNumber() {
 		assertTrue(dropdownObject.isDisplayed());
 		assertEquals(dropdownObject.getAmountOfPossibleValues(), 204);
 	}
-	
+
 	@Test
 	public void testSelectOptionByIndex() {
 		dropdownObject.selectDropdownByIndex(0);
 		assertTrue(dropdownObject.isDropdownElementSelectedByIndex(0));
 	}
-	
+
 	@Test
 	public void testSelectOptionByValue() {
 		dropdownObject.selectDropdownByValue("Vietnam");
 		assertTrue(dropdownObject.isDropdownElementSelectedByValue("Vietnam"));
 	}
-	
+
 	@Test
 	public void testSelectOptionByText() {
 		dropdownObject.selectDropdownByVisibleText("Vietnam");
 		assertEquals(dropdownObject.getFirstSelectedOptionText(), "Vietnam");
 	}
-	
+
 	@Test
 	public void testAllSelectedOptions() {
 		dropdownObject.selectDropdownByIndex(5);
 		assertEquals(dropdownObject.getAllSelectedOptionsText()
 				.size(), 1);
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
@@ -64,9 +62,9 @@ public class DropdownListTest extends BaseTest {
 		this.dropdownObject = BasePage.getDriver()
 				.elementDropdownList(DropdownListTest.dropdownSelector);
 	}
-	
+
 	@Override
 	public void tearDown() {
-		
+
 	}
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/HorizontalSliderTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/HorizontalSliderTest.java
@@ -1,52 +1,51 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.math.BigDecimal;
-
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class HorizontalSliderTest extends BaseTest {
-	
-	private static final By	sliderParent	= By.cssSelector("div#tabs-2");
-	private static final By	sliderSelector	= By.cssSelector("div#slider-range-max");
-	private static final By	valueSelector	= By.cssSelector("#amount1");
-	
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+	private static final By sliderParent   = By.cssSelector("div#tabs-2");
+	private static final By sliderSelector = By.cssSelector("div#slider-range-max");
+	private static final By valueSelector  = By.cssSelector("#amount1");
+
 	private static final String HORIZONTAL_SLIDER_INITIAL_VALUE = "2";
-	
+
 	@Test
 	public void test() {
 		// check if element is displayed
 		assertTrue(BasePage.getDriver()
-						.elementHorizontalSlider(sliderParent)
-						.isDisplayed());
-		
+				.elementHorizontalSlider(sliderParent)
+				.isDisplayed());
+
 		// check if element type equals HoizontalSlider
 		assertEquals("Horizontal Slider", BasePage.getDriver()
-						.elementHorizontalSlider(sliderParent, sliderSelector, valueSelector)
-						.getElementTypeName());
-		
+				.elementHorizontalSlider(sliderParent, sliderSelector, valueSelector)
+				.getElementTypeName());
+
 		// check if element's initial value is equal to 2
 		assertEquals(new BigDecimal(HORIZONTAL_SLIDER_INITIAL_VALUE), BasePage.getDriver()
-						.elementHorizontalSlider(sliderParent, sliderSelector, valueSelector)
-						.getCurrentSliderValue());
+				.elementHorizontalSlider(sliderParent, sliderSelector, valueSelector)
+				.getCurrentSliderValue());
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
-						.get(PageSubURLsEnum.WWW_FONT_URL.subURL() + PageSubURLsEnum.SLIDER.subURL());
+				.get(PageSubURLsEnum.WWW_FONT_URL.subURL() + PageSubURLsEnum.SLIDER.subURL());
 	}
-	
+
 	@Override
 	public void tearDown() {
-		
+
 	}
-	
+
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/ImageTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/ImageTest.java
@@ -13,31 +13,31 @@ import static junit.framework.TestCase.assertTrue;
  * Created by TTRZCINSKI on 19.10.2018.
  */
 public class ImageTest extends BaseTest {
-    private static By img1 = By.cssSelector("img");
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+	private static By img1 = By.cssSelector("img");
 
-    @AfterClass
-    public static void tearDownAll() {
-        BasePage.getDriver()
-                .close();
-    }
+	@AfterClass
+	public static void tearDownAll() {
 
-    @Test
-    public void test() {
-        // check if label is displayed
-        assertTrue(BasePage.getDriver()
-                .elementImage(ImageTest.img1)
-                .isDisplayed());
-    }
+	}
 
-    @Override
-    public void setUp() {
-        BasePage.getDriver()
-                .get(PageSubURLsEnum.TOOLS_QA.subURL() + PageSubURLsEnum.AUTOMATION_PRACTICE_FORM.subURL());
-        return;
-    }
+	@Test
+	public void test() {
+		// check if label is displayed
+		assertTrue(BasePage.getDriver()
+				.elementImage(ImageTest.img1)
+				.isDisplayed());
+	}
 
-    @Override
-    public void tearDown() {
-        // TODO Auto-generated method stub
-    }
+	@Override
+	public void setUp() {
+		BasePage.getDriver()
+				.get(PageSubURLsEnum.TOOLS_QA.subURL() + PageSubURLsEnum.AUTOMATION_PRACTICE_FORM.subURL());
+		return;
+	}
+
+	@Override
+	public void tearDown() {
+		// TODO Auto-generated method stub
+	}
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/InputTextTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/InputTextTest.java
@@ -1,55 +1,53 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.InputTextElement;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by LKURZAJ on 03.03.2017.
  */
 public class InputTextTest extends BaseTest {
-	
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
 	private static By firstNameInputText = By.cssSelector("input[id='name_3_firstname']");
-	
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
+
 	}
-	
+
 	@Test()
 	public void testInputData() {
 		InputTextElement inputElement = BasePage.getDriver()
 				.elementInputText(InputTextTest.firstNameInputText);
-		
+
 		// verify if input text is displayed
 		assertTrue(inputElement.isDisplayed());
-		
+
 		// clear current text and verify (what to call getValue() or getText() depends
 		// on implementation)
 		inputElement.clearInputText();
 		assertEquals("", inputElement.getValue());
-		
+
 		// input some text into input text and verify value
 		inputElement.setInputText("John");
 		assertEquals("John", inputElement.getValue());
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
 				.get(PageSubURLsEnum.WWW_FONT_URL.subURL() + PageSubURLsEnum.REGISTRATION.subURL());
 		return;
 	}
-	
+
 	@Override
 	public void tearDown() {
 		// TODO Auto-generated method stub

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/LabelTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/LabelTest.java
@@ -1,53 +1,53 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-
+import com.capgemini.mrchecker.selenium.core.BasePage;
+import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
+import com.capgemini.mrchecker.test.core.BaseTest;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.capgemini.mrchecker.selenium.core.BasePage;
-import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
-import com.capgemini.mrchecker.test.core.BaseTest;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 /**
  * Created by LKURZAJ on 03.03.2017.
  */
 public class LabelTest extends BaseTest {
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+
 	private static By text1Label = By.cssSelector("span.bcd");
-	
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
+
 	}
-	
+
 	@Test
 	public void test() {
 		// check if label is displayed
 		assertTrue(BasePage.getDriver()
 				.elementLabel(LabelTest.text1Label)
 				.isDisplayed());
-		
+
 		// check if label has properly text
 		assertEquals("Text1", BasePage.getDriver()
 				.elementLabel(LabelTest.text1Label)
 				.getText());
-		
+
 		// check if label has properly class field
 		assertEquals("bcd", BasePage.getDriver()
 				.elementLabel(LabelTest.text1Label)
 				.getClassName());
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
 				.get(PageSubURLsEnum.TOOLS_QA.subURL() + PageSubURLsEnum.AUTOMATION_PRACTICE_FORM.subURL());
 		return;
 	}
-	
+
 	@Override
 	public void tearDown() {
 		// TODO Auto-generated method stub

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/MenuTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/MenuTest.java
@@ -1,38 +1,37 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.MenuElement;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by LKURZAJ on 08.03.2017.
  */
 public class MenuTest extends BaseTest {
-	
-	private final static By menuSelector = By.cssSelector("div#tabs-1 ul.top-level");
-	private final static By menu2Selector = By.cssSelector("div#tabs-2 ul.top-level");
-	private final static By menuChildsSelector = By.cssSelector("li");
-	private final static By subMenuSelector = By.cssSelector("ul");
-	private final static By subMenuChildsSelector = By.cssSelector("li");
-	private final static By subMenuTabSelector = By.cssSelector("li[aria-controls='tabs-2']");
-	private MenuElement menuElement;
-	private MenuElement menu2Element;
-	
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+
+	private final static By          menuSelector          = By.cssSelector("div#tabs-1 ul.top-level");
+	private final static By          menu2Selector         = By.cssSelector("div#tabs-2 ul.top-level");
+	private final static By          menuChildsSelector    = By.cssSelector("li");
+	private final static By          subMenuSelector       = By.cssSelector("ul");
+	private final static By          subMenuChildsSelector = By.cssSelector("li");
+	private final static By          subMenuTabSelector    = By.cssSelector("li[aria-controls='tabs-2']");
+	private              MenuElement menuElement;
+	private              MenuElement menu2Element;
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
+
 	}
-	
+
 	@Test
 	public void testMenuByIndex() {
 		menuElement = BasePage.getDriver()
@@ -40,7 +39,7 @@ public class MenuTest extends BaseTest {
 		menuElement.selectItemByIndex(0);
 		assertEquals(this.getCurrentURL() + "#", menuElement.getItemLinkByIndex(0));
 	}
-	
+
 	@Test
 	public void testMenuByText() {
 		menuElement = BasePage.getDriver()
@@ -48,21 +47,21 @@ public class MenuTest extends BaseTest {
 		menuElement.selectItemByText("About");
 		assertEquals(this.getCurrentURL() + "#", menuElement.getItemLinkByText("About"));
 	}
-	
+
 	@Test
 	public void testMenuItemsCount() {
 		menuElement = BasePage.getDriver()
 				.elementMenu(MenuTest.menuSelector);
 		assertEquals(5, menuElement.getItemsCount());
 	}
-	
+
 	@Test
 	public void testMenuItemsText() {
 		menuElement = BasePage.getDriver()
 				.elementMenu(MenuTest.menuSelector);
 		assertEquals(Arrays.asList("Home", "About", "Contact", "FAQ", "News"), menuElement.getItemsTextList());
 	}
-	
+
 	@Test
 	public void testSelectSubMenuItemByText() {
 		BasePage.getDriver()
@@ -73,7 +72,7 @@ public class MenuTest extends BaseTest {
 						MenuTest.subMenuSelector);
 		assertEquals(getCurrentURL() + "#", menu2Element.getSubMenuItemLinkByText("FAQ", "Sub Menu Item 3"));
 	}
-	
+
 	@Test
 	public void testSelectSubMenuItemByIndex() {
 		BasePage.getDriver()
@@ -83,7 +82,7 @@ public class MenuTest extends BaseTest {
 				.elementMenu(MenuTest.menu2Selector, MenuTest.menuChildsSelector);
 		menu2Element.selectSubMenuItemByIndex(0, 1);
 	}
-	
+
 	@Test
 	public void testLinkSubMenuItemByIndex() {
 		BasePage.getDriver()
@@ -93,7 +92,7 @@ public class MenuTest extends BaseTest {
 				.elementMenu(MenuTest.menu2Selector, MenuTest.menuChildsSelector);
 		assertEquals(getCurrentURL() + "#", menu2Element.getSubMenuItemLinkByIndex(0, 1));
 	}
-	
+
 	@Test
 	public void testLinkSubMenuItemByText() {
 		BasePage.getDriver()
@@ -104,18 +103,18 @@ public class MenuTest extends BaseTest {
 						MenuTest.subMenuSelector, MenuTest.subMenuChildsSelector);
 		menu2Element.selectSubMenuItemByText("FAQ", "Sub Menu Item 3");
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
 				.get(PageSubURLsEnum.WWW_FONT_URL.subURL() + PageSubURLsEnum.MENU.subURL());
 	}
-	
+
 	@Override
 	public void tearDown() {
-		
+
 	}
-	
+
 	private String getCurrentURL() {
 		return PageSubURLsEnum.WWW_FONT_URL.subURL() + PageSubURLsEnum.MENU.subURL();
 	}

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/NavigationBarTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/NavigationBarTest.java
@@ -1,51 +1,48 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.NavigationBarElement;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by LKURZAJ on 07.03.2017.
  */
 public class NavigationBarTest extends BaseTest {
-	
-	private final static By navigationBarSelector = By.cssSelector("ol#breadcrumbs");
-	private final static By childsSelector = By.cssSelector("li");
-	private NavigationBarElement navigationBarElement;
-	
+	private              NavigationBarElement navigationBarElement;
+	private final static By                   navigationBarSelector = By.cssSelector("ol#breadcrumbs");
+	private final static By                   childsSelector        = By.cssSelector("li");
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
+
 	}
-	
+
 	@Test
 	public void testGets() {
 		assertEquals("Home", this.navigationBarElement.getFirstItemText());
 		assertEquals("Tabs", this.navigationBarElement.getActiveItemText());
 	}
-	
+
 	@Test
 	public void testClickByIndex() {
 		this.navigationBarElement.clickItemByIndex(1);
 		assertEquals("Tabs", this.navigationBarElement.getActiveItemText());
 	}
-	
+
 	@Test
 	public void testClickByText() {
 		this.navigationBarElement.clickItemByText("Home");
 		assertEquals("Home", this.navigationBarElement.getActiveItemText());
 	}
-	
+
 	@Test
 	public void testClickActiveItem() {
 		String url = BasePage.getDriver()
@@ -54,20 +51,20 @@ public class NavigationBarTest extends BaseTest {
 		assertEquals(url, BasePage.getDriver()
 				.getCurrentUrl());
 	}
-	
+
 	@Test
 	public void testClickFirstItem() {
 		this.navigationBarElement.clickFirstItem();
 		assertEquals(1, this.navigationBarElement.getDepth());
 	}
-	
+
 	@Test
 	public void testConstructor() {
 		NavigationBarElement navBarElem = BasePage.getDriver()
 				.elementNavigationBar(NavigationBarTest.navigationBarSelector, NavigationBarTest.childsSelector);
 		assertEquals(Arrays.asList("Home", "Tabs"), navBarElem.getItemsTextList());
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
@@ -75,9 +72,9 @@ public class NavigationBarTest extends BaseTest {
 		this.navigationBarElement = BasePage.getDriver()
 				.elementNavigationBar(NavigationBarTest.navigationBarSelector);
 	}
-	
+
 	@Override
 	public void tearDown() {
-		
+
 	}
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/QuickFixSeleniumPage.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/QuickFixSeleniumPage.java
@@ -1,0 +1,24 @@
+package com.capgemini.mrchecker.selenium.core.tests.webElements;
+
+import com.capgemini.mrchecker.selenium.core.BasePage;
+
+public class QuickFixSeleniumPage extends BasePage {
+	//This page is created to fix Selenium Session Exception from tes.WebElements test cases.
+	//When the test cases are refactored, this page should be deleted.
+
+	@Override
+	public boolean isLoaded() {
+		getDriver().waitForPageLoaded();
+		return true;
+	}
+
+	@Override
+	public void load() {
+
+	}
+
+	@Override
+	public String pageTitle() {
+		return getActualPageTitle();
+	}
+}

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/RadioButtonTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/RadioButtonTest.java
@@ -1,42 +1,40 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.RadioButtonElement;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by LKURZAJ on 28.02.2017.
  */
 public class RadioButtonTest extends BaseTest {
-	
-	private RadioButtonElement maritalStatusRadioButton;
-	private final static By selectorMaritalStatus = By.cssSelector("div[class='radio_wrap']");
-	private final static int radioElementsCount = 3;
-	private final static List<String> possibleValues = Arrays.asList("Single", "Married", "Divorced");
-	
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+	private              RadioButtonElement maritalStatusRadioButton;
+	private final static By                 selectorMaritalStatus = By.cssSelector("div[class='radio_wrap']");
+	private final static int                radioElementsCount    = 3;
+	private final static List<String>       possibleValues        = Arrays.asList("Single", "Married", "Divorced");
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
+
 	}
-	
+
 	@Test
 	public void testRadioButtonElementsCount() {
 		// check if appropriate number of radio button elements is displayed
 		assertEquals(radioElementsCount, maritalStatusRadioButton.getItemsCount());
 	}
-	
+
 	@Test
 	public void testPossibleValues() {
 		List<String> elementValues = this.maritalStatusRadioButton.getTextList();
@@ -44,20 +42,20 @@ public class RadioButtonTest extends BaseTest {
 			assertEquals(RadioButtonTest.possibleValues.get(i), elementValues.get(i));
 		}
 	}
-	
+
 	@Test
 	public void testSelection() {
 		// select and check by index
 		maritalStatusRadioButton.selectItemByIndex(0);
 		assertEquals(maritalStatusRadioButton.getSelectedItemIndex(), 0);
 		assertTrue(maritalStatusRadioButton.isItemSelectedByIndex(0));
-		
+
 		// select and check by value
 		maritalStatusRadioButton.selectItemByValue("married");
 		assertEquals(maritalStatusRadioButton.getSelectedItemValue(), "married");
 		assertTrue(maritalStatusRadioButton.isItemSelectedByValue("married"));
 	}
-	
+
 	@Test
 	public void testSelectionSpecifiedItem() {
 		// example of usage Radio Button with other constructor's arguments
@@ -68,7 +66,7 @@ public class RadioButtonTest extends BaseTest {
 		assertEquals(maritalStatusRadioButton.getSelectedItemIndex(), 2);
 		assertTrue(maritalStatusRadioButton.isItemSelectedByIndex(2));
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
@@ -76,10 +74,10 @@ public class RadioButtonTest extends BaseTest {
 		this.maritalStatusRadioButton = BasePage.getDriver()
 				.elementRadioButton(selectorMaritalStatus);
 	}
-	
+
 	@Override
 	public void tearDown() {
 		// TODO Auto-generated method stub
 	}
-	
+
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/TabTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/TabTest.java
@@ -1,43 +1,41 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.TabElement;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by LKURZAJ on 06.03.2017.
  */
 public class TabTest extends BaseTest {
-	
-	private final static By tabSelector = By.cssSelector("ul[role='tablist']");
-	private TabElement tabObject;
-	private final static List<String> possibleValues = Arrays.asList("Tab 1", "Tab 2", "Tab 3");
-	private final static By tabChildsSelector = By.cssSelector("li");
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+	private final static By           tabSelector            = By.cssSelector("ul[role='tablist']");
+	private              TabElement   tabObject;
+	private final static List<String> possibleValues         = Arrays.asList("Tab 1", "Tab 2", "Tab 3");
+	private final static By           tabChildsSelector      = By.cssSelector("li");
 	private final static List<String> listSelectedAttributes = Arrays.asList("ui-tabs-active ui-state-active");
-	
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
+
 	}
-	
+
 	@Test
 	public void testRadioButtonElementsCount() {
 		// check if appropriate number of radio button elements is displayed
 		assertEquals(3, tabObject.getItemsCount());
 	}
-	
+
 	@Test
 	public void testPossibleValues() {
 		List<String> elementValues = this.tabObject.getTextList();
@@ -45,19 +43,19 @@ public class TabTest extends BaseTest {
 			assertEquals(TabTest.possibleValues.get(i), elementValues.get(i));
 		}
 	}
-	
+
 	@Test
 	public void testSelection() {
 		// select and check by index
 		tabObject.selectItemByIndex(2);
 		assertEquals(tabObject.getSelectedItemIndex(), 2);
 		assertTrue(tabObject.isItemSelectedByIndex(2));
-		
+
 		// select and check by text
 		tabObject.selectItemByText("Tab 1");
 		assertEquals(tabObject.getSelectedItemText(), "Tab 1");
 	}
-	
+
 	@Test
 	public void testSelectionSpecifiedItem() {
 		tabObject = BasePage.getDriver()
@@ -67,7 +65,7 @@ public class TabTest extends BaseTest {
 		assertEquals(tabObject.getSelectedItemIndex(), 1);
 		assertTrue(tabObject.isItemSelectedByIndex(1));
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
@@ -75,7 +73,7 @@ public class TabTest extends BaseTest {
 		this.tabObject = BasePage.getDriver()
 				.elementTab(TabTest.tabSelector);
 	}
-	
+
 	@Override
 	public void tearDown() {
 	}

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/TooltipTest.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/test/java/com/capgemini/mrchecker/selenium/core/tests/webElements/TooltipTest.java
@@ -1,31 +1,28 @@
 package com.capgemini.mrchecker.selenium.core.tests.webElements;
 
-import static org.junit.Assert.assertTrue;
-
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-
 import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.core.enums.PageSubURLsEnum;
 import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.TooltipElement;
 import com.capgemini.mrchecker.test.core.BaseTest;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by LKURZAJ on 08.03.2017.
  */
 public class TooltipTest extends BaseTest {
-	
-	private final static By tooltipSelector = By.cssSelector("div.ui-tooltip");
+	QuickFixSeleniumPage quickFixSeleniumPage = new QuickFixSeleniumPage();
+	private final static By tooltipSelector   = By.cssSelector("div.ui-tooltip");
 	private final static By inputTextSelector = By.cssSelector("input[id='age']");
 	TooltipElement tooltipElement;
-	
+
 	@AfterClass
 	public static void tearDownAll() {
-		BasePage.getDriver()
-				.close();
 	}
-	
+
 	@Test
 	public void test() {
 		// hover mouse on input text element
@@ -35,20 +32,20 @@ public class TooltipTest extends BaseTest {
 				.perform();
 		this.tooltipElement = BasePage.getDriver()
 				.elementTooltip(TooltipTest.tooltipSelector);
-		
+
 		// check if tooltip is displayed
 		assertTrue(this.tooltipElement.isDisplayed());
-		
+
 		// check if tooltip text contains appropriate expression
 		assertTrue(this.tooltipElement.isTextContains("We ask for your age"));
 	}
-	
+
 	@Override
 	public void setUp() {
 		BasePage.getDriver()
 				.get(PageSubURLsEnum.WWW_FONT_URL.subURL() + PageSubURLsEnum.TOOLTIP.subURL());
 	}
-	
+
 	@Override
 	public void tearDown() {
 	}


### PR DESCRIPTION
1. Sesion exception BROWSER_TIMEOUT is fixed by using in selenium tests the right structure of test case which inherit BaseTest and test page which inherit BasePage.
2. There is no need to close driver in the test case, because it is done automatically in framework.
3. This is quick fix, the refactoring of test cases is planned to be done with review tasks which are assigned to @MajPat .
