### PR TITLE
Customizes test names handling

### DIFF
--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/BaseTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/BaseTest.java
@@ -62,7 +62,7 @@ public abstract class BaseTest {
 	}
 	
 	private static void setEnvironmentInstance(boolean isEncryptionEnabled) {
-		// Environment variables either from n.csv or any other input data.
+		// Environment variables either from environments.csv or any other input data.
 		IEnvironmentService environmentInstance = Guice.createInjector(new EnvironmentModule())
 				.getInstance(IEnvironmentService.class);
 		environmentInstance.setEnvironment(RuntimeParametersCore.ENV.getValue());

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/BaseTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/BaseTest.java
@@ -62,7 +62,7 @@ public abstract class BaseTest {
 	}
 	
 	private static void setEnvironmentInstance(boolean isEncryptionEnabled) {
-		// Environment variables either from environmnets.csv or any other input data.
+		// Environment variables either from n.csv or any other input data.
 		IEnvironmentService environmentInstance = Guice.createInjector(new EnvironmentModule())
 				.getInstance(IEnvironmentService.class);
 		environmentInstance.setEnvironment(RuntimeParametersCore.ENV.getValue());

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/TestExecutionObserver.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/TestExecutionObserver.java
@@ -144,7 +144,8 @@ public class TestExecutionObserver implements ITestExecutionObserver {
 	}
 	
 	private void printTimeExecutionLog() {
-		BFLogger.logInfo("\"" + testNames.get() + "\"" + getFormattedTestDuration());
+		BFLogger.logInfo("\"" + testNames.get()
+				.getJunitName() + "\"" + getFormattedTestDuration());
 	}
 	
 	private String getFormattedTestDuration() {

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/TestExecutionObserver.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/TestExecutionObserver.java
@@ -10,18 +10,27 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import com.capgemini.mrchecker.test.core.logger.BFLogger;
+import com.capgemini.mrchecker.test.core.logger.EmptyTestName;
+import com.capgemini.mrchecker.test.core.logger.ITestName;
+import com.capgemini.mrchecker.test.core.logger.ITestNameParser;
+import com.capgemini.mrchecker.test.core.logger.JunitOrCucumberRunnerTestNameParser;
 import com.capgemini.mrchecker.test.core.utils.Attachments;
+
+import io.qameta.allure.Allure;
 
 public class TestExecutionObserver implements ITestExecutionObserver {
 	
-	private static TestExecutionObserver instance = new TestExecutionObserver();
+	private static final TestExecutionObserver instance = new TestExecutionObserver();
 	
 	private final ThreadLocal<Long> stopwatch = ThreadLocal.withInitial(() -> 0L);
 	
 	private final ThreadLocal<List<ITestObserver>>	observers		= ThreadLocal.withInitial(ArrayList::new);
 	private final ThreadLocal<List<ITestObserver>>	classObservers	= ThreadLocal.withInitial(ArrayList::new);
+	private final ThreadLocal<ITestName>			testNames		= ThreadLocal.withInitial(EmptyTestName::new);
 	
 	public static final boolean DONT_CONSUME_EXCEPTION_IN_AFTERALL = false;
+	
+	private static final ITestNameParser testNameParser = new JunitOrCucumberRunnerTestNameParser();
 	
 	private TestExecutionObserver() {
 	}
@@ -40,9 +49,13 @@ public class TestExecutionObserver implements ITestExecutionObserver {
 	@Override
 	public void beforeTestExecution(ExtensionContext context) {
 		BFLogger.RestrictedMethods.startSeparateLog();
-		logTestInfo(context, "STARTED");
+		testNames.set(testNameParser.parseFromContext(context));
+		Allure.getLifecycle()
+				.updateTestCase(testResult -> testResult.setName(testNames.get()
+						.getAllureName()));
 		BaseTest.getAnalytics()
 				.sendClassName();
+		logTestInfo("STARTED");
 		stopwatch.set(System.currentTimeMillis());
 		validateTestClassAndCallHook(context, BaseTest::setUp);
 	}
@@ -50,8 +63,8 @@ public class TestExecutionObserver implements ITestExecutionObserver {
 	@Override
 	public void afterTestExecution(ExtensionContext context) {
 		stopwatch.set(System.currentTimeMillis() - stopwatch.get()); // end timing
-		String testName = logTestInfo(context, "FINISHED");
-		printTimeExecutionLog(testName);
+		logTestInfo("FINISHED");
+		printTimeExecutionLog();
 		validateTestClassAndCallHook(context, BaseTest::tearDown);
 	}
 	
@@ -61,19 +74,19 @@ public class TestExecutionObserver implements ITestExecutionObserver {
 	
 	@Override
 	public void testDisabled(ExtensionContext context, Optional<String> reason) {
-		logTestInfo(context, "DISABLED");
+		logTestInfo("DISABLED");
 		reason.ifPresent(s -> BFLogger.logInfo("Reason: " + s));
 	}
 	
 	@Override
 	public void testAborted(ExtensionContext context, Throwable cause) {
-		logTestInfo(context, "ABORTED");
+		logTestInfo("ABORTED");
 		afterEach();
 	}
 	
 	@Override
 	public void testSuccessful(ExtensionContext context) {
-		logTestInfo(context, "PASSED");
+		logTestInfo("PASSED");
 		observers.get()
 				.forEach(ITestObserver::onTestSuccess);
 		classObservers.get()
@@ -83,7 +96,7 @@ public class TestExecutionObserver implements ITestExecutionObserver {
 	
 	@Override
 	public void testFailed(ExtensionContext context, Throwable cause) {
-		logTestInfo(context, "FAILED");
+		logTestInfo("FAILED");
 		observers.get()
 				.forEach(ITestObserver::onTestFailure);
 		classObservers.get()
@@ -91,12 +104,9 @@ public class TestExecutionObserver implements ITestExecutionObserver {
 		afterEach();
 	}
 	
-	private static String logTestInfo(ExtensionContext context, String testStatus) {
-		String className = context.getRequiredTestClass()
-				.getName();
-		String testName = context.getDisplayName();
-		BFLogger.logInfo("\"" + className + "#" + testName + "\"" + " - " + testStatus + ".");
-		return testName;
+	private void logTestInfo(String testStatus) {
+		BFLogger.logInfo("\"" + testNames.get()
+				.getJunitName() + "\"" + " - " + testStatus + ".");
 	}
 	
 	private void afterEach() {
@@ -133,8 +143,8 @@ public class TestExecutionObserver implements ITestExecutionObserver {
 		BFLogger.logDebug("All observers cleared.");
 	}
 	
-	private void printTimeExecutionLog(String testName) {
-		BFLogger.logInfo("\"" + testName + "\"" + getFormattedTestDuration());
+	private void printTimeExecutionLog() {
+		BFLogger.logInfo("\"" + testNames.get() + "\"" + getFormattedTestDuration());
 	}
 	
 	private String getFormattedTestDuration() {

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/CucumberRunnerTestName.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/CucumberRunnerTestName.java
@@ -1,0 +1,24 @@
+package com.capgemini.mrchecker.test.core.logger;
+
+public class CucumberRunnerTestName implements ITestName {
+	
+	private final String junitOrAllureName;
+	
+	private CucumberRunnerTestName(String junitOrAllureName) {
+		this.junitOrAllureName = junitOrAllureName;
+	}
+	
+	@Override
+	public String getJunitName() {
+		return junitOrAllureName;
+	}
+	
+	@Override
+	public String getAllureName() {
+		return junitOrAllureName;
+	}
+	
+	public static CucumberRunnerTestName parseString(String originalName) {
+		return new CucumberRunnerTestName(originalName);
+	}
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/EmptyTestName.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/EmptyTestName.java
@@ -1,0 +1,18 @@
+package com.capgemini.mrchecker.test.core.logger;
+
+public class EmptyTestName implements ITestName {
+	
+	public EmptyTestName() {
+		
+	}
+	
+	@Override
+	public String getJunitName() {
+		return "";
+	}
+	
+	@Override
+	public String getAllureName() {
+		return "";
+	}
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/ITestName.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/ITestName.java
@@ -1,0 +1,7 @@
+package com.capgemini.mrchecker.test.core.logger;
+
+public interface ITestName {
+	String getJunitName();
+	
+	String getAllureName();
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/ITestNameParser.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/ITestNameParser.java
@@ -1,0 +1,7 @@
+package com.capgemini.mrchecker.test.core.logger;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public interface ITestNameParser {
+	ITestName parseFromContext(ExtensionContext context);
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/JunitOrCucumberRunnerTestNameParser.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/JunitOrCucumberRunnerTestNameParser.java
@@ -1,0 +1,37 @@
+package com.capgemini.mrchecker.test.core.logger;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class JunitOrCucumberRunnerTestNameParser implements ITestNameParser {
+	
+	@Override
+	public ITestName parseFromContext(ExtensionContext context) {
+		return context.getRequiredTestClass()
+				.getName()
+				.contains("BaseHook") ? parseCucumber(context) : parseJUnit(context);
+	}
+	
+	private static ITestName parseCucumber(ExtensionContext context) {
+		return CucumberRunnerTestName.parseString(context.getDisplayName());
+	}
+	
+	private static ITestName parseJUnit(ExtensionContext context) {
+		String uniqueId = context.getUniqueId();
+		// [engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[method:Test_orderMenu()]
+		String uniqueIdParsed = uniqueId.substring(uniqueId.indexOf("/") + 1)
+				.replaceAll("([\\[\\]]|\\(.*\\))", "");
+		StringBuilder sb = new StringBuilder();
+		String[] parts = uniqueIdParsed.split("/");
+		
+		for (int i = 0; i < 2; i++) {
+			sb.append(parts[i].split(":")[1])
+					.append(":");
+			if (parts[i].contains("test-template")) {
+				sb.append(context.getDisplayName())
+						.append(":");
+			}
+		}
+		sb.deleteCharAt(sb.length() - 1);
+		return JunitRunnerTestName.parseString(sb.toString());
+	}
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/JunitOrCucumberRunnerTestNameParser.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/JunitOrCucumberRunnerTestNameParser.java
@@ -1,5 +1,8 @@
 package com.capgemini.mrchecker.test.core.logger;
 
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class JunitOrCucumberRunnerTestNameParser implements ITestNameParser {
@@ -17,21 +20,35 @@ public class JunitOrCucumberRunnerTestNameParser implements ITestNameParser {
 	
 	private static ITestName parseJUnit(ExtensionContext context) {
 		String uniqueId = context.getUniqueId();
-		// [engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[method:Test_orderMenu()]
 		String uniqueIdParsed = uniqueId.substring(uniqueId.indexOf("/") + 1)
 				.replaceAll("([\\[\\]]|\\(.*\\))", "");
-		StringBuilder sb = new StringBuilder();
 		String[] parts = uniqueIdParsed.split("/");
 		
-		for (int i = 0; i < 2; i++) {
-			sb.append(parts[i].split(":")[1])
-					.append(":");
-			if (parts[i].contains("test-template")) {
-				sb.append(context.getDisplayName())
+		StringBuilder sb = new StringBuilder();
+		sb.append(parts[0].split(":")[1])
+				.append(":");
+		
+		Method testMethod = context.getRequiredTestMethod();
+		boolean isDDT = parts[1].contains("test-template");
+		String displayName = context.getDisplayName();
+		displayName = displayName.substring(displayName.indexOf("]") + 1)
+				.replaceAll("\\(.*\\)", "");
+		
+		if (testMethod.isAnnotationPresent(DisplayName.class)) {
+			sb.append(testMethod.getAnnotation(DisplayName.class)
+					.value());
+			if (isDDT) {
+				sb.append(":")
+						.append(displayName);
+			}
+		} else {
+			if (isDDT) {
+				sb.append(parts[1].split(":")[1])
 						.append(":");
 			}
+			sb.append(displayName);
 		}
-		sb.deleteCharAt(sb.length() - 1);
+		
 		return JunitRunnerTestName.parseString(sb.toString());
 	}
 }

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/JunitRunnerTestName.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/logger/JunitRunnerTestName.java
@@ -1,0 +1,26 @@
+package com.capgemini.mrchecker.test.core.logger;
+
+public class JunitRunnerTestName implements ITestName {
+	
+	private final String	junitName;
+	private final String	allureName;
+	
+	private JunitRunnerTestName(String junitName, String allureName) {
+		this.junitName = junitName;
+		this.allureName = allureName;
+	}
+	
+	@Override
+	public String getJunitName() {
+		return junitName;
+	}
+	
+	@Override
+	public String getAllureName() {
+		return allureName;
+	}
+	
+	public static JunitRunnerTestName parseString(String originalName) {
+		return new JunitRunnerTestName(originalName, originalName.substring(originalName.indexOf(":") + 1));
+	}
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/integration/logger/JunitAndCucumberRunnerTestNameParserTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/integration/logger/JunitAndCucumberRunnerTestNameParserTest.java
@@ -6,6 +6,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -16,52 +19,76 @@ import com.capgemini.mrchecker.test.core.tags.IntegrationTest;
 
 @IntegrationTest
 public class JunitAndCucumberRunnerTestNameParserTest {
-	private static final String	JUNIT_RUNNER_DISPLAYED_NAME_NO_TDD	= "Test_orderMenu()";
-	private static final String	JUNIT_RUNNER_UNIQUE_ID_NO_TDD		= "[engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[method:Test_orderMenu()]";
+	private static final String	JUNIT_RUNNER_DISPLAYED_NAME_NO_DDT	= "Test_orderMenu()";
+	private static final String	JUNIT_RUNNER_UNIQUE_ID_NO_DDT		= "[engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[method:Test_orderMenu()]";
 	
-	private static final String	JUNIT_RUNNER_DISPLAYED_NAME_TDD	= "[1] waiter, waiter";
-	private static final String	JUNIT_RUNNER_UNIQUE_ID_TDD		= "[engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[test-template:Test_loginAndLogOut(com.capgemini.mrchecker.common.mts.data.User)]/[test-template-invocation:#1]";
+	private static final String	JUNIT_RUNNER_DISPLAYED_NAME_DDT	= "[1] waiter, waiter";
+	private static final String	JUNIT_RUNNER_UNIQUE_ID_DDT		= "[engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[test-template:Test_loginAndLogOut(com.capgemini.mrchecker.common.mts.data.User)]/[test-template-invocation:#1]";
+	private static final String	EXPECTED_ALLURE_NAME_DDT		= "Test_loginAndLogOut: waiter, waiter";
 	
 	private static final String	CUCUMBER_RUNNER_DISPLAYED_NAME	= "Cucumber test name (scenario line: 1)";
-	private static final String	CUCUMBER_RUNNER_UNIQUE_ID_TDD	= "";
+	private static final String	CUCUMBER_RUNNER_UNIQUE_ID_DDT	= "";
 	
 	private static final ITestNameParser SUT = new JunitOrCucumberRunnerTestNameParser();
 	
 	@Test
-	public void shouldParseJunitRunnerNoTDDName() {
-		ITestName parsedTestName = SUT.parseFromContext(createMockedExtensionContext(JUNIT_RUNNER_DISPLAYED_NAME_NO_TDD, JUNIT_RUNNER_UNIQUE_ID_NO_TDD, Object.class));
+	public void shouldParseJunitRunnerNoDDTName() throws NoSuchMethodException {
+		ITestName parsedTestName = SUT.parseFromContext(
+				createMockedExtensionContext(JUNIT_RUNNER_DISPLAYED_NAME_NO_DDT, JUNIT_RUNNER_UNIQUE_ID_NO_DDT, Object.class, getClass().getMethod("shouldParseJunitRunnerNoDDTName")));
 		
-		assertThat(parsedTestName.getJunitName(), is(equalTo("com.capgemini.mrchecker.selenium.mts.MyThaiStarTest" + ":" + "Test_orderMenu")));
+		assertThat(parsedTestName.getJunitName(), is(equalTo("com.capgemini.mrchecker.selenium.mts.MyThaiStarTest:Test_orderMenu")));
 		assertThat(parsedTestName.getAllureName(), is(equalTo("Test_orderMenu")));
 	}
 	
 	@Test
-	public void shouldParseJunitRunnerTDDName() {
-		ITestName parsedTestName = SUT.parseFromContext(createMockedExtensionContext(JUNIT_RUNNER_DISPLAYED_NAME_TDD, JUNIT_RUNNER_UNIQUE_ID_TDD, Object.class));
-		String testNameSuffix = "Test_loginAndLogOut" + ":" + JUNIT_RUNNER_DISPLAYED_NAME_TDD;
+	@DisplayName("shouldParseJunitRunnerNoDDTAnnotatedName")
+	public void shouldParseJunitRunnerNoDDTAnnotatedName() throws NoSuchMethodException {
+		ITestName parsedTestName = SUT.parseFromContext(
+				createMockedExtensionContext(JUNIT_RUNNER_DISPLAYED_NAME_NO_DDT, JUNIT_RUNNER_UNIQUE_ID_NO_DDT, Object.class, getClass().getMethod("shouldParseJunitRunnerNoDDTAnnotatedName")));
 		
-		assertThat(parsedTestName.getJunitName(), is(equalTo("com.capgemini.mrchecker.selenium.mts.MyThaiStarTest" + ":" + testNameSuffix)));
-		assertThat(parsedTestName.getAllureName(), is(equalTo(testNameSuffix)));
+		assertThat(parsedTestName.getJunitName(), is(equalTo("com.capgemini.mrchecker.selenium.mts.MyThaiStarTest:shouldParseJunitRunnerNoDDTAnnotatedName")));
+		assertThat(parsedTestName.getAllureName(), is(equalTo("shouldParseJunitRunnerNoDDTAnnotatedName")));
 	}
 	
 	@Test
-	public void shouldParseCucumberRunnerName() {
-		ITestName parsedTestName = SUT.parseFromContext(createMockedExtensionContext(CUCUMBER_RUNNER_DISPLAYED_NAME, CUCUMBER_RUNNER_UNIQUE_ID_TDD, BaseHookTest.class));
+	public void shouldParseJunitRunnerDDTName() throws NoSuchMethodException {
+		ITestName parsedTestName = SUT
+				.parseFromContext(createMockedExtensionContext(JUNIT_RUNNER_DISPLAYED_NAME_DDT, JUNIT_RUNNER_UNIQUE_ID_DDT, Object.class, getClass().getMethod("shouldParseJunitRunnerDDTName")));
+		
+		assertThat(parsedTestName.getJunitName(), is(equalTo("com.capgemini.mrchecker.selenium.mts.MyThaiStarTest" + ":" + EXPECTED_ALLURE_NAME_DDT)));
+		assertThat(parsedTestName.getAllureName(), is(equalTo(EXPECTED_ALLURE_NAME_DDT)));
+	}
+	
+	@Test
+	@DisplayName("shouldParseJunitRunnerDDTAnnotatedName")
+	public void shouldParseJunitRunnerDDTAnnotatedName() throws NoSuchMethodException {
+		ITestName parsedTestName = SUT
+				.parseFromContext(
+						createMockedExtensionContext(JUNIT_RUNNER_DISPLAYED_NAME_DDT, JUNIT_RUNNER_UNIQUE_ID_DDT, Object.class, getClass().getMethod("shouldParseJunitRunnerDDTAnnotatedName")));
+		
+		assertThat(parsedTestName.getJunitName(), is(equalTo("com.capgemini.mrchecker.selenium.mts.MyThaiStarTest:shouldParseJunitRunnerDDTAnnotatedName: waiter, waiter")));
+		assertThat(parsedTestName.getAllureName(), is(equalTo("shouldParseJunitRunnerDDTAnnotatedName: waiter, waiter")));
+	}
+	
+	@Test
+	public void shouldParseCucumberRunnerName() throws NoSuchMethodException {
+		ITestName parsedTestName = SUT
+				.parseFromContext(
+						createMockedExtensionContext(CUCUMBER_RUNNER_DISPLAYED_NAME, CUCUMBER_RUNNER_UNIQUE_ID_DDT, BaseHookTest.class, getClass().getMethod("shouldParseCucumberRunnerName")));
 		
 		assertThat(parsedTestName.getJunitName(), is(equalTo(CUCUMBER_RUNNER_DISPLAYED_NAME)));
 		assertThat(parsedTestName.getAllureName(), is(equalTo(CUCUMBER_RUNNER_DISPLAYED_NAME)));
 	}
 	
-	private static ExtensionContext createMockedExtensionContext(String displayedTestName, String uniqueId, Class testInstanceClass) {
+	private static ExtensionContext createMockedExtensionContext(String displayedTestName, String uniqueId, Class testInstanceClass, Method testMethod) {
 		ExtensionContext contextMock = mock(ExtensionContext.class);
 		when(contextMock.getDisplayName()).thenReturn(displayedTestName);
 		when(contextMock.getUniqueId()).thenReturn(uniqueId);
 		when(contextMock.getRequiredTestClass()).thenReturn(testInstanceClass);
+		when(contextMock.getRequiredTestMethod()).thenReturn(testMethod);
 		return contextMock;
 	}
 	
 	private static class BaseHookTest {
-		
 	}
-	
 }

--- a/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/integration/logger/JunitAndCucumberRunnerTestNameParserTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/integration/logger/JunitAndCucumberRunnerTestNameParserTest.java
@@ -1,0 +1,67 @@
+package com.capgemini.mrchecker.test.core.integration.logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.capgemini.mrchecker.test.core.logger.ITestName;
+import com.capgemini.mrchecker.test.core.logger.ITestNameParser;
+import com.capgemini.mrchecker.test.core.logger.JunitOrCucumberRunnerTestNameParser;
+import com.capgemini.mrchecker.test.core.tags.IntegrationTest;
+
+@IntegrationTest
+public class JunitAndCucumberRunnerTestNameParserTest {
+	private static final String	JUNIT_RUNNER_DISPLAYED_NAME_NO_TDD	= "Test_orderMenu()";
+	private static final String	JUNIT_RUNNER_UNIQUE_ID_NO_TDD		= "[engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[method:Test_orderMenu()]";
+	
+	private static final String	JUNIT_RUNNER_DISPLAYED_NAME_TDD	= "[1] waiter, waiter";
+	private static final String	JUNIT_RUNNER_UNIQUE_ID_TDD		= "[engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[test-template:Test_loginAndLogOut(com.capgemini.mrchecker.common.mts.data.User)]/[test-template-invocation:#1]";
+	
+	private static final String	CUCUMBER_RUNNER_DISPLAYED_NAME	= "Cucumber test name (scenario line: 1)";
+	private static final String	CUCUMBER_RUNNER_UNIQUE_ID_TDD	= "";
+	
+	private static final ITestNameParser SUT = new JunitOrCucumberRunnerTestNameParser();
+	
+	@Test
+	public void shouldParseJunitRunnerNoTDDName() {
+		ITestName parsedTestName = SUT.parseFromContext(createMockedExtensionContext(JUNIT_RUNNER_DISPLAYED_NAME_NO_TDD, JUNIT_RUNNER_UNIQUE_ID_NO_TDD, Object.class));
+		
+		assertThat(parsedTestName.getJunitName(), is(equalTo("com.capgemini.mrchecker.selenium.mts.MyThaiStarTest" + ":" + "Test_orderMenu")));
+		assertThat(parsedTestName.getAllureName(), is(equalTo("Test_orderMenu")));
+	}
+	
+	@Test
+	public void shouldParseJunitRunnerTDDName() {
+		ITestName parsedTestName = SUT.parseFromContext(createMockedExtensionContext(JUNIT_RUNNER_DISPLAYED_NAME_TDD, JUNIT_RUNNER_UNIQUE_ID_TDD, Object.class));
+		String testNameSuffix = "Test_loginAndLogOut" + ":" + JUNIT_RUNNER_DISPLAYED_NAME_TDD;
+		
+		assertThat(parsedTestName.getJunitName(), is(equalTo("com.capgemini.mrchecker.selenium.mts.MyThaiStarTest" + ":" + testNameSuffix)));
+		assertThat(parsedTestName.getAllureName(), is(equalTo(testNameSuffix)));
+	}
+	
+	@Test
+	public void shouldParseCucumberRunnerName() {
+		ITestName parsedTestName = SUT.parseFromContext(createMockedExtensionContext(CUCUMBER_RUNNER_DISPLAYED_NAME, CUCUMBER_RUNNER_UNIQUE_ID_TDD, BaseHookTest.class));
+		
+		assertThat(parsedTestName.getJunitName(), is(equalTo(CUCUMBER_RUNNER_DISPLAYED_NAME)));
+		assertThat(parsedTestName.getAllureName(), is(equalTo(CUCUMBER_RUNNER_DISPLAYED_NAME)));
+	}
+	
+	private static ExtensionContext createMockedExtensionContext(String displayedTestName, String uniqueId, Class testInstanceClass) {
+		ExtensionContext contextMock = mock(ExtensionContext.class);
+		when(contextMock.getDisplayName()).thenReturn(displayedTestName);
+		when(contextMock.getUniqueId()).thenReturn(uniqueId);
+		when(contextMock.getRequiredTestClass()).thenReturn(testInstanceClass);
+		return contextMock;
+	}
+	
+	private static class BaseHookTest {
+		
+	}
+	
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/TestExecutionObserverBaseTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/TestExecutionObserverBaseTest.java
@@ -25,6 +25,7 @@ public class TestExecutionObserverBaseTest {
 		when(contextMock.getTestClass()).thenReturn(Optional.of(TestExecutionObserverBaseTest.class));
 		when(contextMock.getRequiredTestClass()).thenCallRealMethod();
 		when(contextMock.getDisplayName()).thenReturn("Test_name");
+		when(contextMock.getUniqueId()).thenReturn("[engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[method:Test_orderMenu()]");
 		
 		observerMock = mock(ITestObserver.class);
 		when(observerMock.getModuleType()).thenReturn(ModuleType.CORE);

--- a/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/TestExecutionObserverTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/TestExecutionObserverTest.java
@@ -39,6 +39,7 @@ public class TestExecutionObserverTest {
 		when(contextMock.getTestClass()).thenReturn(Optional.of(TestExecutionObserverTest.class));
 		when(contextMock.getRequiredTestClass()).thenCallRealMethod();
 		when(contextMock.getDisplayName()).thenReturn("Test_name");
+		when(contextMock.getUniqueId()).thenReturn("[engine:junit-jupiter]/[class:com.capgemini.mrchecker.selenium.mts.MyThaiStarTest]/[method:Test_orderMenu()]");
 		
 		observerMock = mock(ITestObserver.class);
 		when(observerMock.getModuleType()).thenReturn(ModuleType.CORE);

--- a/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/logger/CucumberRunnerTestNameTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/logger/CucumberRunnerTestNameTest.java
@@ -1,0 +1,29 @@
+package com.capgemini.mrchecker.test.core.unit.logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import com.capgemini.mrchecker.test.core.logger.CucumberRunnerTestName;
+import com.capgemini.mrchecker.test.core.logger.ITestName;
+import com.capgemini.mrchecker.test.core.tags.UnitTest;
+
+@UnitTest
+public class CucumberRunnerTestNameTest {
+	
+	private static final String TEST_NAME = "Cucumber scenario: 1";
+	
+	private static final ITestName SUT = CucumberRunnerTestName.parseString(TEST_NAME);
+	
+	@Test
+	public void shouldReturnJunitName() {
+		assertThat(SUT.getJunitName(), is(equalTo(TEST_NAME)));
+	}
+	
+	@Test
+	public void shouldReturnAllureName() {
+		assertThat(SUT.getAllureName(), is(equalTo(TEST_NAME)));
+	}
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/logger/EmptyTestNameTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/logger/EmptyTestNameTest.java
@@ -1,0 +1,26 @@
+package com.capgemini.mrchecker.test.core.unit.logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import com.capgemini.mrchecker.test.core.logger.EmptyTestName;
+import com.capgemini.mrchecker.test.core.logger.ITestName;
+import com.capgemini.mrchecker.test.core.tags.UnitTest;
+
+@UnitTest
+public class EmptyTestNameTest {
+	private static final ITestName SUT = new EmptyTestName();
+	
+	@Test
+	public void shouldReturnJunitName() {
+		assertThat(SUT.getJunitName(), is(equalTo("")));
+	}
+	
+	@Test
+	public void shouldReturnAllureName() {
+		assertThat(SUT.getAllureName(), is(equalTo("")));
+	}
+}

--- a/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/logger/JunitRunnerTestNameTest.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/test/java/com/capgemini/mrchecker/test/core/unit/logger/JunitRunnerTestNameTest.java
@@ -1,0 +1,31 @@
+package com.capgemini.mrchecker.test.core.unit.logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import com.capgemini.mrchecker.test.core.logger.ITestName;
+import com.capgemini.mrchecker.test.core.logger.JunitRunnerTestName;
+import com.capgemini.mrchecker.test.core.tags.UnitTest;
+
+@UnitTest
+public class JunitRunnerTestNameTest {
+	private static final String	TEST_CLASS	= "com.TestClass";
+	private static final String	TEST_METHOD	= "method()";
+	
+	private static final String TEST_NAME = TEST_CLASS + ":" + TEST_METHOD;
+	
+	private static final ITestName SUT = JunitRunnerTestName.parseString(TEST_NAME);
+	
+	@Test
+	public void shouldReturnJunitName() {
+		assertThat(SUT.getJunitName(), is(equalTo(TEST_NAME)));
+	}
+	
+	@Test
+	public void shouldReturnAllureName() {
+		assertThat(SUT.getAllureName(), is(equalTo(TEST_METHOD)));
+	}
+}


### PR DESCRIPTION
Test case naming is now handled by MrChecker. The test names are formatted for BFLogger and Allure differently, supports running from both Junit and Cucumber runners as well as DDT.