### PR TITLE
add options to handle gpg problems

### DIFF
--- a/mrchecker-framework-modules/pom.xml
+++ b/mrchecker-framework-modules/pom.xml
@@ -534,6 +534,14 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <!-- Prevent `gpg` from using pinentry programs -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                        <arg>--batch</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
For now attempt to sign artifacts from develop branch ends up with `gpg: signing failed: Inappropriate ioctl for device` 
Solution suggested here https://github.com/keybase/keybase-issues/issues/2798 is not working for some reason but we could go with loopback and --batch. For some reson pinentry-mode is also required (as I set this up on my branch long time ago I forgot why but I guess the problem was providing passwords and key securely)