### PR TITLE
bugfix

### DIFF
--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/newDrivers/DriverManager.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/newDrivers/DriverManager.java
@@ -320,6 +320,7 @@ public class DriverManager {
         setPlatformName(capabilities);
 
         NewRemoteWebDriver newRemoteWebDriver = null;
+        capabilities.setBrowserName(options.getBrowserName())
         try {
             newRemoteWebDriver = new NewRemoteWebDriver(new URL(SELENIUM_GRID_URL), capabilities);
         } catch (MalformedURLException e) {


### PR DESCRIPTION
Bug description:

Browser EDGE = new Browser() {
        public String browserName() {
            return "MicrosoftEdge";
        }

Code above probably is necer executed. Issue occurs during executing tests on Edge on Selenium Grid (name of browser should be "MicrosoftEdge", but there is "edge" sent)