### PR TITLE
JDK 11

### DIFF
--- a/mrchecker-framework-modules/mrchecker-core-module/pom.xml
+++ b/mrchecker-framework-modules/mrchecker-core-module/pom.xml
@@ -80,7 +80,7 @@
         <!-- Cucumber version -->
         <cucumber.version>7.14.0</cucumber.version>
         <gherkin.cucumber.version>27.0.0</gherkin.cucumber.version>
-        <cucumber-reporting.version>5.7.6</cucumber-reporting.version>
+        <cucumber-reporting.version>5.7.7</cucumber-reporting.version>
 
         <!--GSON-->
         <gson.version>2.10.1</gson.version>

--- a/mrchecker-framework-modules/mrchecker-core-module/pom.xml
+++ b/mrchecker-framework-modules/mrchecker-core-module/pom.xml
@@ -158,11 +158,6 @@
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-java8</artifactId>
-            <version>${cucumber.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>
             <version>${cucumber.version}</version>
         </dependency>

--- a/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/TestExecutionObserver.java
+++ b/mrchecker-framework-modules/mrchecker-core-module/src/main/java/com/capgemini/mrchecker/test/core/TestExecutionObserver.java
@@ -100,7 +100,7 @@ public class TestExecutionObserver implements ITestExecutionObserver {
     //AfterTestExecutionCallback
     @Override
     public void afterTestExecution(ExtensionContext inputContext) {
-        ExtensionContext context = inputContext == null ? extensionContext.get() : inputContext;
+        var context = inputContext == null ? extensionContext.get() : inputContext;
         setExtensionContext(context);
         stopwatch.set(System.currentTimeMillis() - stopwatch.get()); // end timing
         logTestInfo("FINISHED");

--- a/mrchecker-framework-modules/mrchecker-database-module/pom.xml
+++ b/mrchecker-framework-modules/mrchecker-database-module/pom.xml
@@ -70,9 +70,9 @@
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 
         <jpa.version>2.2</jpa.version>
-        <hibernate-core.version>6.1.7.Final</hibernate-core.version>
-        <mysql-connector-j.version>8.0.32</mysql-connector-j.version>
-        <byte-buddy.version>1.14.0</byte-buddy.version>
+        <hibernate-core.version>6.3.1.Final</hibernate-core.version>
+        <mysql-connector-j.version>8.1.0</mysql-connector-j.version>
+        <byte-buddy.version>1.14.8</byte-buddy.version>
     </properties>
 
     <dependencies>

--- a/mrchecker-framework-modules/mrchecker-mobile-module/pom.xml
+++ b/mrchecker-framework-modules/mrchecker-mobile-module/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 
         <!-- Lib/package version settings -->
-        <io.appium.java.client.version>8.3.0</io.appium.java.client.version>
+        <io.appium.java.client.version>8.5.1</io.appium.java.client.version>
     </properties>
 
     <dependencies>

--- a/mrchecker-framework-modules/mrchecker-selenium-module/pom.xml
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/pom.xml
@@ -78,7 +78,7 @@
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 
         <!-- Selenium settings -->
-        <selenium.version>4.12.1</selenium.version>
+        <selenium.version>4.13.0</selenium.version>
 
         <webdrivermanager.version>5.5.3</webdrivermanager.version>
         <google-api-client.version>2.2.0</google-api-client.version>

--- a/mrchecker-framework-modules/mrchecker-selenium-module/pom.xml
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/pom.xml
@@ -78,7 +78,7 @@
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 
         <!-- Selenium settings -->
-        <selenium.version>4.13.0</selenium.version>
+        <selenium.version>4.14.0</selenium.version>
 
         <webdrivermanager.version>5.5.3</webdrivermanager.version>
         <google-api-client.version>2.2.0</google-api-client.version>

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/newDrivers/DriverManager.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/newDrivers/DriverManager.java
@@ -21,7 +21,10 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.ie.InternetExplorerOptions;
-import org.openqa.selenium.remote.*;
+import org.openqa.selenium.remote.AbstractDriverOptions;
+import org.openqa.selenium.remote.Browser;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.net.MalformedURLException;
@@ -330,7 +333,7 @@ public class DriverManager {
     }
 
     private static void setBrowserName(DesiredCapabilities capabilities, MutableCapabilities options) {
-        BrowserType browserType = BrowserType.get();
+        var browserType = BrowserType.get();
         switch (browserType) {
             case CHROME:
                 capabilities.setCapability(ChromeOptions.CAPABILITY, options);

--- a/mrchecker-framework-modules/mrchecker-webapi-module/pom.xml
+++ b/mrchecker-framework-modules/mrchecker-webapi-module/pom.xml
@@ -69,7 +69,7 @@
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 
         <!-- Lib/package version settings -->
-        <wiremock.version>2.27.2</wiremock.version>
+        <wiremock.version>3.2.0</wiremock.version>
         <wiremock-body-transformer.version>1.1.6</wiremock-body-transformer.version>
         <java-xmlbuilder.version>1.3</java-xmlbuilder.version>
 
@@ -124,10 +124,9 @@
         </dependency>
 
         <!-- Dependency to start mock API -->
+        <!-- https://mvnrepository.com/artifact/org.wiremock/wiremock -->
         <dependency>
-            <!-- http://wiremock.org/docs/ -->
-            <!-- https://github.com/tomakehurst/wiremock/blob/master/src/test/java/ignored/Examples.java#374 -->
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
         </dependency>

--- a/mrchecker-framework-modules/pom.xml
+++ b/mrchecker-framework-modules/pom.xml
@@ -97,7 +97,7 @@
         <surefire.provider.version>1.3.2</surefire.provider.version>
 
         <!-- Test tools -->
-        <mockito.version>4.11.0</mockito.version>
+        <mockito.version>5.6.0</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>
         <junit.version>5.10.0</junit.version>
         <junit.platform.version>1.10.0</junit.platform.version>
@@ -210,7 +210,6 @@
 
         </dependencies>
     </dependencyManagement>
-
 
     <!-- The bellow dependencies will ba automatically included in modules -->
     <dependencies>
@@ -545,7 +544,6 @@
                         </executions>
                     </plugin>
 
-
                     <!-- <plugin>
                         <groupId>com.coderplus.maven.plugins</groupId>
                         <artifactId>copy-rename-maven-plugin</artifactId>
@@ -656,7 +654,6 @@
             </reporting>
 
         </profile>
-
 
         <profile>
             <id>default</id>

--- a/mrchecker-framework-modules/pom.xml
+++ b/mrchecker-framework-modules/pom.xml
@@ -90,7 +90,7 @@
         <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
 
         <!-- Java settings -->
-        <java.compiler.version>1.8</java.compiler.version>
+        <java.compiler.version>11</java.compiler.version>
 
         <!-- Tests executors -->
         <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
@@ -451,8 +451,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -683,7 +683,7 @@
                                             <version>3.3.9</version>
                                         </requireMavenVersion>
                                         <requireJavaVersion>
-                                            <version>1.8</version>
+                                            <version>11</version>
                                         </requireJavaVersion>
                                     </rules>
                                 </configuration>


### PR DESCRIPTION
**### Changelog**
- Configured JDK 11 as required minimum
- Used **_var_** keyword in few places to be sure JDK 11 is used
- Removed no longer needed Cucumber Java 8 dependency

**### Evidences**

Selenium JUnit example project tests results
![image](https://github.com/devonfw-forge/mrchecker-source/assets/20811235/1a1a8109-402c-4a2b-9c5f-c55179f7cee7)

Selenium Cucumber example project tests results
![image](https://github.com/devonfw-forge/mrchecker-source/assets/20811235/ebdc230f-ca8e-42bf-9b9d-c0ae8d3db4f9)
