### PR TITLE
Implemented logs and exception handling when RelativeBy is used

### DIFF
--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/exceptions/BFElementNotFoundException.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/exceptions/BFElementNotFoundException.java
@@ -4,9 +4,10 @@ import com.capgemini.mrchecker.test.core.logger.BFLogger;
 import com.capgemini.mrchecker.test.core.utils.DurationUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.support.locators.RelativeLocator;
 
 import java.time.Duration;
+
+import static com.capgemini.mrchecker.selenium.core.utils.ByToString.getReadableByName;
 
 public class BFElementNotFoundException extends NoSuchElementException {
 
@@ -115,7 +116,7 @@ public class BFElementNotFoundException extends NoSuchElementException {
     }
 
     private static String generateStandardMessage(By by) {
-        return getExceutedMethodName() + "\nElement '" + getReadableSelector(by) + "' was not found. Check printscreen.\n";
+        return getExceutedMethodName() + "\nElement '" + getReadableByName(by) + "' was not found. Check printscreen.\n";
 
     }
 
@@ -148,18 +149,5 @@ public class BFElementNotFoundException extends NoSuchElementException {
             message = message + messageTimeout;
         }
         return message;
-    }
-
-    private static String getReadableSelector(By selector) {
-        if (selector instanceof RelativeLocator.RelativeBy) {
-            return getReadableRelativeBy((RelativeLocator.RelativeBy) selector);
-        }
-        return selector.toString();
-    }
-
-    private static String getReadableRelativeBy(RelativeLocator.RelativeBy relativeLocator) {
-        return relativeLocator.getRemoteParameters()
-                              .toString()
-                              .replaceAll("\\[\\[\\[\\[New\\w+Driver.*?->[^]]+]", "WebElement");
     }
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/exceptions/BFElementNotFoundException.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/exceptions/BFElementNotFoundException.java
@@ -4,6 +4,7 @@ import com.capgemini.mrchecker.test.core.logger.BFLogger;
 import com.capgemini.mrchecker.test.core.utils.DurationUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.support.locators.RelativeLocator;
 
 import java.time.Duration;
 
@@ -114,7 +115,7 @@ public class BFElementNotFoundException extends NoSuchElementException {
     }
 
     private static String generateStandardMessage(By by) {
-        return getExceutedMethodName() + "\nElement '" + by.toString() + "' was not found. Check printscreen.\n";
+        return getExceutedMethodName() + "\nElement '" + getReadableSelector(by) + "' was not found. Check printscreen.\n";
 
     }
 
@@ -149,4 +150,16 @@ public class BFElementNotFoundException extends NoSuchElementException {
         return message;
     }
 
+    private static String getReadableSelector(By selector) {
+        if (selector instanceof RelativeLocator.RelativeBy) {
+            return getReadableRelativeBy((RelativeLocator.RelativeBy) selector);
+        }
+        return selector.toString();
+    }
+
+    private static String getReadableRelativeBy(RelativeLocator.RelativeBy relativeLocator) {
+        return relativeLocator.getRemoteParameters()
+                              .toString()
+                              .replaceAll("\\[\\[\\[\\[New\\w+Driver.*?->[^]]+]", "WebElement");
+    }
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/newDrivers/DriverExtension.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/newDrivers/DriverExtension.java
@@ -6,6 +6,7 @@ import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.*;
 import com.capgemini.mrchecker.test.core.logger.BFLogger;
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.locators.RelativeLocator;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
@@ -42,7 +43,7 @@ public class DriverExtension {
         try {
             element = Objects.isNull(elementToSearchIn) ? getDriver().findElement(by) : new NewRemoteWebElement(elementToSearchIn).findElement(by);
         } catch (NoSuchElementException e) {
-            BFLogger.logError("Element [" + by.toString() + "] was not found in given element");
+            BFLogger.logError("Element [" + getReadableSelector(by) + "] was not found in given element");
         }
         return element;
     }
@@ -77,7 +78,7 @@ public class DriverExtension {
             boolean isTimeout = true;
             throw new BFElementNotFoundException(by, isTimeout, timeOut);
         }
-        BFLogger.logTime(startTime, "findElementDynamic()", by.toString());
+        BFLogger.logTime(startTime, "findElementDynamic()", getReadableSelector(by));
         return element;
     }
 
@@ -93,9 +94,9 @@ public class DriverExtension {
             throw new BFElementNotFoundException(by, true, timeOut);
         }
         if (elements.isEmpty()) {
-            BFLogger.logError("Not found element : " + by.toString() + ".");
+            BFLogger.logError("Not found element : " + getReadableSelector(by) + ".");
         }
-        BFLogger.logTime(startTime, "findElementDynamics()", by.toString());
+        BFLogger.logTime(startTime, "findElementDynamics()", getReadableSelector(by));
         return elements;
     }
 
@@ -118,7 +119,7 @@ public class DriverExtension {
             boolean isTimeout = true;
             throw new BFElementNotFoundException(by, isTimeout, DriverManager.EXPLICIT_WAIT);
         }
-        BFLogger.logTime(startTime, "waitForElement()", by.toString());
+        BFLogger.logTime(startTime, "waitForElement()", getReadableSelector(by));
         return element;
     }
 
@@ -133,7 +134,7 @@ public class DriverExtension {
             boolean isTimeout = true;
             throw new BFElementNotFoundException(by, isTimeout, DriverManager.EXPLICIT_WAIT);
         }
-        BFLogger.logTime(startTime, "waitUntilElementIsClickable()", by.toString());
+        BFLogger.logTime(startTime, "waitUntilElementIsClickable()", getReadableSelector(by));
         return element;
     }
 
@@ -149,7 +150,7 @@ public class DriverExtension {
             boolean isTimeout = true;
             throw new BFElementNotFoundException(by, isTimeout, DriverManager.EXPLICIT_WAIT);
         }
-        BFLogger.logTime(startTime, "waitForElementVisible()", by.toString());
+        BFLogger.logTime(startTime, "waitForElementVisible()", getReadableSelector(by));
         return element;
     }
 
@@ -366,4 +367,16 @@ public class DriverExtension {
                 .perform();
     }
 
+    private String getReadableSelector(By selector) {
+        if (selector instanceof RelativeLocator.RelativeBy) {
+            return getReadableRelativeBy((RelativeLocator.RelativeBy) selector);
+        }
+        return selector.toString();
+    }
+
+    private String getReadableRelativeBy(RelativeLocator.RelativeBy relativeLocator) {
+        return relativeLocator.getRemoteParameters()
+                              .toString()
+                              .replaceAll("\\[\\[\\[\\[New\\w+Driver.*?->[^]]+]", "WebElement");
+    }
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/newDrivers/DriverExtension.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/newDrivers/DriverExtension.java
@@ -6,7 +6,6 @@ import com.capgemini.mrchecker.selenium.core.newDrivers.elementType.*;
 import com.capgemini.mrchecker.test.core.logger.BFLogger;
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.support.locators.RelativeLocator;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
@@ -17,6 +16,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import static com.capgemini.mrchecker.selenium.core.utils.ByToString.getReadableByName;
 
 public class DriverExtension {
 
@@ -43,7 +44,7 @@ public class DriverExtension {
         try {
             element = Objects.isNull(elementToSearchIn) ? getDriver().findElement(by) : new NewRemoteWebElement(elementToSearchIn).findElement(by);
         } catch (NoSuchElementException e) {
-            BFLogger.logError("Element [" + getReadableSelector(by) + "] was not found in given element");
+            BFLogger.logError("Element [" + getReadableByName(by) + "] was not found in given element");
         }
         return element;
     }
@@ -78,7 +79,7 @@ public class DriverExtension {
             boolean isTimeout = true;
             throw new BFElementNotFoundException(by, isTimeout, timeOut);
         }
-        BFLogger.logTime(startTime, "findElementDynamic()", getReadableSelector(by));
+        BFLogger.logTime(startTime, "findElementDynamic()", getReadableByName(by));
         return element;
     }
 
@@ -94,9 +95,9 @@ public class DriverExtension {
             throw new BFElementNotFoundException(by, true, timeOut);
         }
         if (elements.isEmpty()) {
-            BFLogger.logError("Not found element : " + getReadableSelector(by) + ".");
+            BFLogger.logError("Not found element : " + getReadableByName(by) + ".");
         }
-        BFLogger.logTime(startTime, "findElementDynamics()", getReadableSelector(by));
+        BFLogger.logTime(startTime, "findElementDynamics()", getReadableByName(by));
         return elements;
     }
 
@@ -119,7 +120,7 @@ public class DriverExtension {
             boolean isTimeout = true;
             throw new BFElementNotFoundException(by, isTimeout, DriverManager.EXPLICIT_WAIT);
         }
-        BFLogger.logTime(startTime, "waitForElement()", getReadableSelector(by));
+        BFLogger.logTime(startTime, "waitForElement()", getReadableByName(by));
         return element;
     }
 
@@ -134,7 +135,7 @@ public class DriverExtension {
             boolean isTimeout = true;
             throw new BFElementNotFoundException(by, isTimeout, DriverManager.EXPLICIT_WAIT);
         }
-        BFLogger.logTime(startTime, "waitUntilElementIsClickable()", getReadableSelector(by));
+        BFLogger.logTime(startTime, "waitUntilElementIsClickable()", getReadableByName(by));
         return element;
     }
 
@@ -150,7 +151,7 @@ public class DriverExtension {
             boolean isTimeout = true;
             throw new BFElementNotFoundException(by, isTimeout, DriverManager.EXPLICIT_WAIT);
         }
-        BFLogger.logTime(startTime, "waitForElementVisible()", getReadableSelector(by));
+        BFLogger.logTime(startTime, "waitForElementVisible()", getReadableByName(by));
         return element;
     }
 
@@ -365,18 +366,5 @@ public class DriverExtension {
         new Actions(getDriver()).click(element)
                 .build()
                 .perform();
-    }
-
-    private String getReadableSelector(By selector) {
-        if (selector instanceof RelativeLocator.RelativeBy) {
-            return getReadableRelativeBy((RelativeLocator.RelativeBy) selector);
-        }
-        return selector.toString();
-    }
-
-    private String getReadableRelativeBy(RelativeLocator.RelativeBy relativeLocator) {
-        return relativeLocator.getRemoteParameters()
-                              .toString()
-                              .replaceAll("\\[\\[\\[\\[New\\w+Driver.*?->[^]]+]", "WebElement");
     }
 }

--- a/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/utils/ByToString.java
+++ b/mrchecker-framework-modules/mrchecker-selenium-module/src/main/java/com/capgemini/mrchecker/selenium/core/utils/ByToString.java
@@ -1,0 +1,20 @@
+package com.capgemini.mrchecker.selenium.core.utils;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.locators.RelativeLocator.RelativeBy;
+
+public final class ByToString {
+
+    public static String getReadableByName(By selector) {
+        if (selector instanceof RelativeBy) {
+            return getReadableRelativeByName((RelativeBy) selector);
+        }
+        return selector.toString();
+    }
+
+    private static String getReadableRelativeByName(RelativeBy relativeLocator) {
+        return relativeLocator.getRemoteParameters()
+                              .toString()
+                              .replaceAll("\\[\\[\\[\\[New\\w+Driver.*?->[^]]+]", "WebElement");
+    }
+}


### PR DESCRIPTION
**Hi,
I think that this implementation might be useful.**
<br>

 **Now logs looks like this:**
```java
logDebug - Waiting for [findElementDynamic(): [unknown locator]] took [0.029 s]
```

**and exceptions like this:**
```java
Element '[unknown locator]' was not found. Check printscreen.
```
<br>

**Now they can look like this:**

- logs using selectors
```java
logDebug - Waiting for [findElementDynamic(): [relative: {root={css selector=#login\-button}, filters=[{kind=below, args=[{css selector=#password}]}]}]] took [0.031 s]
```

- logs using webelements
```java
logDebug - Waiting for [findElementDynamic(): [relative: {root={css selector=#login\-button}, filters=[{kind=below, args=[WebElement -> id: user-name]] -> id: user-name]]}]}]] -> id: user-name]]}]}]]}]}]] took [0.022 s]
```

- exception using selectors
```java
Element '[relative: {root={css selector=#login\-button\-niedobry}, filters=[{kind=above, args=[{css selector=#password\-tez\-zle}]}]}]' was not found. Check printscreen.
```

- exception using webelements
```java
Element '[relative: {root={css selector=#login\-button\-niedobry}, filters=[{kind=above, args=[WebElement] -> id: user-name]]}, {kind=below, args=[WebElement -> id: user-name]] -> id: user-name]]}]}]] -> id: user-name]]}]}]]}]}]' was not found. Check printscreen.
```
<br>

**On the string extracted from the RelativeBy parameters, I used a replacement to "WebElement" 
when using these particular objects.
Without this, the logs/exceptions could be very long and unreadable:**

```java
Element '[relative: {root={css selector=#login\-button\-niedobry}, filters=[{kind=above, args=[[[[[NewChromeDriver: chrome on windows (67107c5852f151f8513f43d4788840ac)] -> id: user-name]] -> id: user-name]]}, {kind=below, args=[[[[[NewChromeDriver: chrome on windows (67107c5852f151f8513f43d4788840ac)] -> relative: {root={css selector=#password}, filters=[{kind=below, args=[[[[[NewChromeDriver: chrome on windows (67107c5852f151f8513f43d4788840ac)] -> id: user-name]] -> id: user-name]]}]}]] -> id: user-name]]}]}]]}]}]' was not found. Check printscreen.
```
<br>

**And here is a demo of the regex I used:**
![regex demo](https://github.com/devonfw-forge/mrchecker-source/assets/87763712/a0a10473-a5de-4df8-b57c-dac21ce135c7)
